### PR TITLE
Update Nmap.nsi.in

### DIFF
--- a/mswin32/nsis/Nmap.nsi.in
+++ b/mswin32/nsis/Nmap.nsi.in
@@ -374,7 +374,8 @@ FunctionEnd
 Function create_uninstaller
   StrCmp $addremoveset "" 0 skipaddremove
   ; Register Nmap with add/remove programs 
-  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Nmap" "DisplayName" "Nmap ${VERSION}" 
+  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Nmap" "DisplayName" "Nmap ${VERSION}"
+  WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Nmap" "DisplayVersion" "${VERSION}"  
   WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Nmap" "UninstallString" '"$INSTDIR\uninstall.exe"' 
   WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Nmap" "DisplayIcon" '"$INSTDIR\icon1.ico"' 
   WriteRegDWORD HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\Nmap" "NoModify" 1 


### PR DESCRIPTION
The windows un-install registry key is missing the "DisplayVersion" key. 

Some scripted installers and un-installers depend on the 'version' number being set to the installed version number.

Once the key is set the "Version" field in the 'add/remove' section will be filled in.

<img width="963" alt="nmap-7 x-no-windows-registry-uninstall-displayversion-set" src="https://cloud.githubusercontent.com/assets/471105/12016572/fb3c3bd8-ad4c-11e5-854c-ba7264826796.png">
